### PR TITLE
[OCPBUGS-41497] `network.MachineNetwork` parameter not required in case of Baremetal UPI cluster installation

### DIFF
--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -67,6 +67,11 @@ endif::agnostic[]
 
 You can customize the `install-config.yaml` file to specify more details about your {product-title} cluster's platform or modify the values of the required parameters.
 
+[NOTE]
+====
+In the below example, `network.machineNetwork` is excluded, as it is assumed that the network will be provided by end user during the installation process. Installer never asks for `network.machineNetwork` value.
+====
+
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: v1


### PR DESCRIPTION
[OCPBUGS-41497] `network.MachineNetwork` parameter not required in case of Baremetal UPI cluster installation.

Need to update information regarding network.machineNetwork.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. --> 

Issue: 
https://issues.redhat.com/browse/OCPBUGS-41497
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: May need to cherry picking in other supported RHOCP versions.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
